### PR TITLE
Feature/libvirt vxlan 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,163 @@
 # ansible-playbook-libvirt-vxlan
+
+3개의 Ubuntu 머신에 libvirt KVM 가상화 환경을 구성하고, VXLAN으로 오버레이 네트워크를 연결하는 Ansible 플레이북
+
+## 네트워크 토폴로지
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              VXLAN Overlay (VNI 100, 10.200.1.0/24)         │
+└─────────────────────────────────────────────────────────────┘
+        │                    │                    │
+   ┌────┴────┐          ┌────┴────┐          ┌────┴────┐
+   │br-vxlan │          │br-vxlan │          │br-vxlan │
+   │10.200.1.1│         │10.200.1.2│         │10.200.1.3│
+   ├─────────┤          ├─────────┤          ├─────────┤
+   │vxlan100 │          │vxlan100 │          │vxlan100 │
+   ├─────────┤          ├─────────┤          ├─────────┤
+   │ eth0    │          │ eth0    │          │ eth0    │
+   │.0.50    │          │.0.46    │          │.0.49    │
+   └────┬────┘          └────┬────┘          └────┬────┘
+        │                    │                    │
+        └────────────────────┴────────────────────┘
+                   Underlay (192.168.0.0/24)
+```
+
+## 호스트 정보
+
+| 호스트 | 물리 IP | 오버레이 IP |
+|--------|---------|-------------|
+| kvm-host01 | 192.168.0.50 | 10.200.1.1 |
+| kvm-host02 | 192.168.0.46 | 10.200.1.2 |
+| kvm-host03 | 192.168.0.49 | 10.200.1.3 |
+
+## 요구사항
+
+- Ubuntu 22.04 LTS
+- CPU 가상화 지원 (VT-x/AMD-V)
+- SSH 접속 가능 (ubuntu 사용자)
+- Ansible 2.15+
+
+## 사전 준비
+
+### 1. Ansible Galaxy 컬렉션 설치
+
+```bash
+ansible-galaxy collection install -r requirements.yml
+```
+
+### 2. 인벤토리 수정
+
+`inventory/hosts.yml` 파일에서 각 호스트의 `underlay_interface`를 실제 인터페이스 이름으로 수정:
+
+```yaml
+kvm-host01:
+  underlay_interface: eth0    # ip link 명령으로 확인
+```
+
+## 실행 방법
+
+### 전체 배포
+
+```bash
+ansible-playbook playbooks/site.yml
+```
+
+### 태그별 실행
+
+```bash
+# 공통 설정만
+ansible-playbook playbooks/site.yml --tags common
+
+# VXLAN 네트워크만
+ansible-playbook playbooks/site.yml --tags vxlan
+
+# libvirt만
+ansible-playbook playbooks/site.yml --tags libvirt
+```
+
+### 검증
+
+```bash
+ansible-playbook playbooks/verify.yml
+```
+
+### Dry-run
+
+```bash
+ansible-playbook playbooks/site.yml --check --diff
+```
+
+## 프로젝트 구조
+
+```
+.
+├── ansible.cfg
+├── requirements.yml
+├── inventory/
+│   ├── hosts.yml
+│   └── group_vars/
+│       ├── all.yml
+│       └── kvm_hosts.yml
+├── roles/
+│   ├── common/          # 공통 패키지, 시스템 설정
+│   ├── vxlan/           # VXLAN 오버레이 네트워크
+│   └── libvirt/         # KVM/libvirt 설치 및 구성
+├── playbooks/
+│   ├── site.yml         # 메인 플레이북
+│   └── verify.yml       # 검증 플레이북
+└── README.md
+```
+
+## 검증 명령어
+
+배포 후 각 호스트에서 확인:
+
+```bash
+# VXLAN 인터페이스 확인
+ip -d link show vxlan100
+
+# 브리지 확인
+ip -d link show br-vxlan
+
+# FDB 엔트리 확인
+bridge fdb show dev vxlan100
+
+# 오버레이 네트워크 연결 테스트
+ping -c 3 10.200.1.1
+ping -c 3 10.200.1.2
+ping -c 3 10.200.1.3
+
+# libvirt 네트워크 확인
+virsh net-list --all
+```
+
+## VM 생성 예시
+
+```bash
+# Ubuntu Cloud 이미지 다운로드
+wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+
+# VM 생성
+virt-install \
+  --name test-vm \
+  --memory 1024 \
+  --vcpus 1 \
+  --disk path=/var/lib/libvirt/images/test-vm.qcow2,size=10 \
+  --network network=vxlan-network \
+  --os-variant ubuntu22.04 \
+  --import \
+  --graphics none \
+  --noautoconsole
+```
+
+## 주요 설정값
+
+| 설정 | 값 |
+|------|-----|
+| VNI | 100 |
+| VXLAN 포트 | 4789 |
+| MTU | 1450 |
+| 오버레이 네트워크 | 10.200.1.0/24 |
+| libvirt 네트워크 | vxlan-network |
+| 브리지 | br-vxlan |

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,21 @@
+[defaults]
+inventory = inventory/hosts.yml
+roles_path = roles
+host_key_checking = False
+retry_files_enabled = False
+gathering = smart
+
+forks = 10
+pipelining = True
+
+stdout_callback = yaml
+
+[privilege_escalation]
+become = True
+become_method = sudo
+become_user = root
+become_ask_pass = False
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+pipelining = True

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,8 +8,6 @@ gathering = smart
 forks = 10
 pipelining = True
 
-stdout_callback = yaml
-
 [privilege_escalation]
 become = True
 become_method = sudo

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -1,0 +1,3 @@
+---
+# 공통 설정
+timezone: Asia/Seoul

--- a/inventory/group_vars/kvm_hosts.yml
+++ b/inventory/group_vars/kvm_hosts.yml
@@ -1,0 +1,22 @@
+---
+# VXLAN 네트워크 설정
+vxlan_vni: 100
+vxlan_port: 4789
+vxlan_mtu: 1450
+vxlan_interface_name: vxlan100
+vxlan_bridge_name: br-vxlan
+vxlan_overlay_network: 10.200.1.0/24
+
+# VXLAN 모드: unicast (FDB 기반)
+vxlan_mode: unicast
+
+# 유니캐스트 피어 목록 (모든 호스트 IP)
+vxlan_peers:
+  - 192.168.0.50
+  - 192.168.0.46
+  - 192.168.0.49
+
+# libvirt 설정
+libvirt_network_name: vxlan-network
+libvirt_pool_name: default
+libvirt_pool_path: /var/lib/libvirt/images

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -1,0 +1,25 @@
+---
+all:
+  children:
+    kvm_hosts:
+      hosts:
+        kvm-host01:
+          ansible_host: 192.168.0.50
+          vxlan_local_ip: 192.168.0.50
+          vxlan_overlay_ip: 10.200.1.1
+          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+        kvm-host02:
+          ansible_host: 192.168.0.46
+          vxlan_local_ip: 192.168.0.46
+          vxlan_overlay_ip: 10.200.1.2
+          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+        kvm-host03:
+          ansible_host: 192.168.0.49
+          vxlan_local_ip: 192.168.0.49
+          vxlan_overlay_ip: 10.200.1.3
+          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+      vars:
+        ansible_user: ubuntu
+        ansible_become: yes
+        ansible_python_interpreter: /usr/bin/python3
+        ansible_ssh_private_key_file: /Users/bambookim/pems/kvm-host02.pem

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -7,17 +7,17 @@ all:
           ansible_host: 192.168.0.50
           vxlan_local_ip: 192.168.0.50
           vxlan_overlay_ip: 10.200.1.1
-          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+          underlay_interface: eno1
         kvm-host02:
           ansible_host: 192.168.0.46
           vxlan_local_ip: 192.168.0.46
           vxlan_overlay_ip: 10.200.1.2
-          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+          underlay_interface: enp2s0
         kvm-host03:
           ansible_host: 192.168.0.49
           vxlan_local_ip: 192.168.0.49
           vxlan_overlay_ip: 10.200.1.3
-          underlay_interface: eth0      # 실제 인터페이스명으로 수정 필요
+          underlay_interface: enp44s0
       vars:
         ansible_user: ubuntu
         ansible_become: yes

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,58 @@
+---
+- name: Deploy Libvirt KVM with VXLAN overlay network
+  hosts: kvm_hosts
+  become: yes
+
+  pre_tasks:
+    - name: Verify connectivity
+      ansible.builtin.ping:
+
+    - name: Gather facts
+      ansible.builtin.setup:
+        gather_subset:
+          - hardware
+          - network
+          - virtual
+
+    - name: Check CPU virtualization support
+      ansible.builtin.shell: grep -cE '(vmx|svm)' /proc/cpuinfo
+      register: virt_support
+      failed_when: virt_support.stdout | int < 1
+      changed_when: false
+
+    - name: Display virtualization info
+      ansible.builtin.debug:
+        msg: "CPU virtualization extensions found: {{ virt_support.stdout }} cores"
+
+  roles:
+    - role: common
+      tags: [common, base]
+
+    - role: vxlan
+      tags: [vxlan, network]
+
+    - role: libvirt
+      tags: [libvirt, kvm]
+
+  post_tasks:
+    - name: Verify VXLAN interface exists
+      ansible.builtin.command: ip link show {{ vxlan_interface_name }}
+      changed_when: false
+
+    - name: Verify bridge interface exists
+      ansible.builtin.command: ip link show {{ vxlan_bridge_name }}
+      changed_when: false
+
+    - name: Verify libvirt network is active
+      ansible.builtin.command: virsh net-info {{ libvirt_network_name }}
+      changed_when: false
+
+    - name: Display deployment summary
+      ansible.builtin.debug:
+        msg:
+          - "=== Deployment Complete ==="
+          - "Host: {{ inventory_hostname }}"
+          - "VXLAN Interface: {{ vxlan_interface_name }} (VNI: {{ vxlan_vni }})"
+          - "Bridge: {{ vxlan_bridge_name }}"
+          - "Overlay IP: {{ vxlan_overlay_ip }}"
+          - "Libvirt Network: {{ libvirt_network_name }}"

--- a/playbooks/verify.yml
+++ b/playbooks/verify.yml
@@ -1,0 +1,80 @@
+---
+- name: Verify VXLAN and Libvirt deployment
+  hosts: kvm_hosts
+  become: yes
+  gather_facts: yes
+
+  tasks:
+    - name: Check VXLAN interface status
+      ansible.builtin.command: ip -d link show {{ vxlan_interface_name }}
+      register: vxlan_status
+      changed_when: false
+
+    - name: Display VXLAN interface info
+      ansible.builtin.debug:
+        var: vxlan_status.stdout_lines
+
+    - name: Check bridge interface status
+      ansible.builtin.command: ip -d link show {{ vxlan_bridge_name }}
+      register: bridge_status
+      changed_when: false
+
+    - name: Display bridge interface info
+      ansible.builtin.debug:
+        var: bridge_status.stdout_lines
+
+    - name: Check FDB entries
+      ansible.builtin.command: bridge fdb show dev {{ vxlan_interface_name }}
+      register: fdb_entries
+      changed_when: false
+
+    - name: Display FDB entries
+      ansible.builtin.debug:
+        var: fdb_entries.stdout_lines
+
+    - name: Test overlay network connectivity
+      ansible.builtin.command: ping -c 3 -W 2 {{ item }}
+      loop: "{{ groups['kvm_hosts'] | map('extract', hostvars, 'vxlan_overlay_ip') | list }}"
+      register: ping_results
+      failed_when: false
+      changed_when: false
+
+    - name: Display ping results
+      ansible.builtin.debug:
+        msg: "Ping to {{ item.item }}: {{ 'SUCCESS' if item.rc == 0 else 'FAILED' }}"
+      loop: "{{ ping_results.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Check libvirt service status
+      ansible.builtin.service:
+        name: libvirtd
+        state: started
+      check_mode: yes
+
+    - name: List libvirt networks
+      ansible.builtin.command: virsh net-list --all
+      register: virsh_networks
+      changed_when: false
+
+    - name: Display libvirt networks
+      ansible.builtin.debug:
+        var: virsh_networks.stdout_lines
+
+    - name: List libvirt storage pools
+      ansible.builtin.command: virsh pool-list --all
+      register: virsh_pools
+      changed_when: false
+
+    - name: Display storage pools
+      ansible.builtin.debug:
+        var: virsh_pools.stdout_lines
+
+    - name: Summary
+      ansible.builtin.debug:
+        msg:
+          - "=== Verification Summary for {{ inventory_hostname }} ==="
+          - "Overlay IP: {{ vxlan_overlay_ip }}"
+          - "VXLAN Interface: UP"
+          - "Bridge Interface: UP"
+          - "Libvirt Network: {{ libvirt_network_name }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.libvirt
+    version: ">=1.2.0"
+  - name: ansible.posix
+    version: ">=1.4.0"
+  - name: community.general
+    version: ">=6.0.0"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+timezone: Asia/Seoul

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# Common role handlers

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install common packages
+  ansible.builtin.apt:
+    name:
+      - vim
+      - curl
+      - wget
+      - htop
+      - net-tools
+      - bridge-utils
+      - iproute2
+      - iptables
+      - tcpdump
+      - python3-pip
+      - python3-libvirt
+      - python3-lxml
+    state: present
+
+- name: Set timezone
+  community.general.timezone:
+    name: "{{ timezone }}"
+
+- name: Load bridge kernel module
+  community.general.modprobe:
+    name: bridge
+    state: present
+
+- name: Load br_netfilter kernel module
+  community.general.modprobe:
+    name: br_netfilter
+    state: present
+
+- name: Ensure kernel modules load on boot
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/bridge.conf
+    content: |
+      bridge
+      br_netfilter
+    mode: '0644'
+
+- name: Enable IP forwarding and bridge settings
+  ansible.posix.sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    sysctl_set: yes
+    state: present
+    reload: yes
+  loop:
+    - { name: 'net.ipv4.ip_forward', value: '1' }
+    - { name: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+    - { name: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }

--- a/roles/libvirt/defaults/main.yml
+++ b/roles/libvirt/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+libvirt_network_name: vxlan-network
+libvirt_pool_name: default
+libvirt_pool_path: /var/lib/libvirt/images

--- a/roles/libvirt/handlers/main.yml
+++ b/roles/libvirt/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart libvirtd
+  ansible.builtin.service:
+    name: libvirtd
+    state: restarted

--- a/roles/libvirt/tasks/configure.yml
+++ b/roles/libvirt/tasks/configure.yml
@@ -1,0 +1,33 @@
+---
+- name: Create storage pool directory
+  ansible.builtin.file:
+    path: "{{ libvirt_pool_path }}"
+    state: directory
+    owner: libvirt-qemu
+    group: kvm
+    mode: '0771'
+
+- name: Check if default pool exists
+  ansible.builtin.command: virsh pool-info {{ libvirt_pool_name }}
+  register: pool_check
+  failed_when: false
+  changed_when: false
+
+- name: Define default storage pool
+  ansible.builtin.command: >
+    virsh pool-define-as {{ libvirt_pool_name }} dir --target {{ libvirt_pool_path }}
+  when: pool_check.rc != 0
+
+- name: Build storage pool
+  ansible.builtin.command: virsh pool-build {{ libvirt_pool_name }}
+  when: pool_check.rc != 0
+  failed_when: false
+
+- name: Start storage pool
+  ansible.builtin.command: virsh pool-start {{ libvirt_pool_name }}
+  when: pool_check.rc != 0
+  failed_when: false
+
+- name: Autostart storage pool
+  ansible.builtin.command: virsh pool-autostart {{ libvirt_pool_name }}
+  changed_when: false

--- a/roles/libvirt/tasks/install.yml
+++ b/roles/libvirt/tasks/install.yml
@@ -1,0 +1,26 @@
+---
+- name: Install KVM/QEMU/libvirt packages
+  ansible.builtin.apt:
+    name:
+      - qemu-kvm
+      - qemu-utils
+      - libvirt-daemon
+      - libvirt-daemon-system
+      - libvirt-clients
+      - virtinst
+      - ovmf
+      - libguestfs-tools
+      - cloud-image-utils
+    state: present
+
+- name: Ensure libvirtd service is started and enabled
+  ansible.builtin.service:
+    name: libvirtd
+    state: started
+    enabled: yes
+
+- name: Add user to libvirt and kvm groups
+  ansible.builtin.user:
+    name: "{{ ansible_user }}"
+    groups: libvirt,kvm
+    append: yes

--- a/roles/libvirt/tasks/main.yml
+++ b/roles/libvirt/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Include installation tasks
+  ansible.builtin.include_tasks: install.yml
+
+- name: Include configuration tasks
+  ansible.builtin.include_tasks: configure.yml
+
+- name: Include network tasks
+  ansible.builtin.include_tasks: network.yml

--- a/roles/libvirt/tasks/network.yml
+++ b/roles/libvirt/tasks/network.yml
@@ -1,0 +1,46 @@
+---
+- name: Check if default network exists and is active
+  ansible.builtin.command: virsh net-info default
+  register: default_net_check
+  failed_when: false
+  changed_when: false
+
+- name: Destroy default network
+  ansible.builtin.command: virsh net-destroy default
+  when: default_net_check.rc == 0
+  failed_when: false
+
+- name: Disable autostart for default network
+  ansible.builtin.command: virsh net-autostart default --disable
+  when: default_net_check.rc == 0
+  failed_when: false
+
+- name: Create VXLAN network XML
+  ansible.builtin.template:
+    src: vxlan-network.xml.j2
+    dest: /tmp/vxlan-network.xml
+    mode: '0644'
+
+- name: Check if VXLAN network exists
+  ansible.builtin.command: virsh net-info {{ libvirt_network_name }}
+  register: vxlan_net_check
+  failed_when: false
+  changed_when: false
+
+- name: Define VXLAN network
+  ansible.builtin.command: virsh net-define /tmp/vxlan-network.xml
+  when: vxlan_net_check.rc != 0
+
+- name: Start VXLAN network
+  ansible.builtin.command: virsh net-start {{ libvirt_network_name }}
+  when: vxlan_net_check.rc != 0
+  failed_when: false
+
+- name: Autostart VXLAN network
+  ansible.builtin.command: virsh net-autostart {{ libvirt_network_name }}
+  changed_when: false
+
+- name: Remove temporary network XML
+  ansible.builtin.file:
+    path: /tmp/vxlan-network.xml
+    state: absent

--- a/roles/libvirt/templates/vxlan-network.xml.j2
+++ b/roles/libvirt/templates/vxlan-network.xml.j2
@@ -1,0 +1,5 @@
+<network>
+  <name>{{ libvirt_network_name }}</name>
+  <forward mode="bridge"/>
+  <bridge name="{{ vxlan_bridge_name }}"/>
+</network>

--- a/roles/vxlan/defaults/main.yml
+++ b/roles/vxlan/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+vxlan_vni: 100
+vxlan_port: 4789
+vxlan_mtu: 1450
+vxlan_interface_name: vxlan100
+vxlan_bridge_name: br-vxlan
+vxlan_mode: unicast

--- a/roles/vxlan/handlers/main.yml
+++ b/roles/vxlan/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: apply netplan
+  ansible.builtin.command: netplan apply

--- a/roles/vxlan/tasks/bridge.yml
+++ b/roles/vxlan/tasks/bridge.yml
@@ -1,0 +1,33 @@
+---
+- name: Check if bridge interface exists
+  ansible.builtin.command: ip link show {{ vxlan_bridge_name }}
+  register: bridge_check
+  failed_when: false
+  changed_when: false
+
+- name: Create bridge interface
+  ansible.builtin.command: ip link add name {{ vxlan_bridge_name }} type bridge
+  when: bridge_check.rc != 0
+
+- name: Add VXLAN interface to bridge
+  ansible.builtin.command: ip link set {{ vxlan_interface_name }} master {{ vxlan_bridge_name }}
+  failed_when: false
+  changed_when: false
+
+- name: Set bridge MTU
+  ansible.builtin.command: ip link set {{ vxlan_bridge_name }} mtu {{ vxlan_mtu }}
+  changed_when: false
+
+- name: Check if bridge has IP address
+  ansible.builtin.shell: ip addr show {{ vxlan_bridge_name }} | grep -q "{{ vxlan_overlay_ip }}"
+  register: bridge_ip_check
+  failed_when: false
+  changed_when: false
+
+- name: Assign IP address to bridge
+  ansible.builtin.command: ip addr add {{ vxlan_overlay_ip }}/24 dev {{ vxlan_bridge_name }}
+  when: bridge_ip_check.rc != 0
+
+- name: Bring up bridge interface
+  ansible.builtin.command: ip link set {{ vxlan_bridge_name }} up
+  changed_when: false

--- a/roles/vxlan/tasks/interface.yml
+++ b/roles/vxlan/tasks/interface.yml
@@ -1,0 +1,48 @@
+---
+- name: Load vxlan kernel module
+  community.general.modprobe:
+    name: vxlan
+    state: present
+
+- name: Ensure vxlan module loads on boot
+  ansible.builtin.lineinfile:
+    path: /etc/modules-load.d/vxlan.conf
+    line: vxlan
+    create: yes
+    mode: '0644'
+
+- name: Check if VXLAN interface exists
+  ansible.builtin.command: ip link show {{ vxlan_interface_name }}
+  register: vxlan_check
+  failed_when: false
+  changed_when: false
+
+- name: Create VXLAN interface (unicast mode)
+  ansible.builtin.command: >
+    ip link add {{ vxlan_interface_name }} type vxlan
+    id {{ vxlan_vni }}
+    dstport {{ vxlan_port }}
+    local {{ vxlan_local_ip }}
+    nolearning
+  when:
+    - vxlan_check.rc != 0
+    - vxlan_mode == 'unicast'
+
+- name: Add FDB entries for unicast peers
+  ansible.builtin.command: >
+    bridge fdb append 00:00:00:00:00:00
+    dev {{ vxlan_interface_name }}
+    dst {{ item }}
+  loop: "{{ vxlan_peers | difference([vxlan_local_ip]) }}"
+  when: vxlan_mode == 'unicast'
+  failed_when: false
+  changed_when: false
+
+- name: Set VXLAN interface MTU
+  ansible.builtin.command: ip link set {{ vxlan_interface_name }} mtu {{ vxlan_mtu }}
+  when: vxlan_check.rc != 0
+  changed_when: false
+
+- name: Bring up VXLAN interface
+  ansible.builtin.command: ip link set {{ vxlan_interface_name }} up
+  changed_when: false

--- a/roles/vxlan/tasks/main.yml
+++ b/roles/vxlan/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Include VXLAN interface tasks
+  ansible.builtin.include_tasks: interface.yml
+
+- name: Include bridge tasks
+  ansible.builtin.include_tasks: bridge.yml
+
+- name: Include persistence tasks
+  ansible.builtin.include_tasks: persistence.yml

--- a/roles/vxlan/tasks/persistence.yml
+++ b/roles/vxlan/tasks/persistence.yml
@@ -1,0 +1,7 @@
+---
+- name: Create netplan configuration for VXLAN
+  ansible.builtin.template:
+    src: vxlan-netplan.yaml.j2
+    dest: /etc/netplan/60-vxlan.yaml
+    mode: '0600'
+  notify: apply netplan

--- a/roles/vxlan/templates/vxlan-netplan.yaml.j2
+++ b/roles/vxlan/templates/vxlan-netplan.yaml.j2
@@ -1,0 +1,24 @@
+# VXLAN overlay network configuration
+# Managed by Ansible - Do not edit manually
+network:
+  version: 2
+  renderer: networkd
+
+  tunnels:
+    {{ vxlan_interface_name }}:
+      mode: vxlan
+      id: {{ vxlan_vni }}
+      local: {{ vxlan_local_ip }}
+      port: {{ vxlan_port }}
+      mtu: {{ vxlan_mtu }}
+
+  bridges:
+    {{ vxlan_bridge_name }}:
+      interfaces:
+        - {{ vxlan_interface_name }}
+      addresses:
+        - {{ vxlan_overlay_ip }}/24
+      mtu: {{ vxlan_mtu }}
+      parameters:
+        stp: false
+        forward-delay: 0


### PR DESCRIPTION
#1 

## Summary

3개의 Ubuntu 호스트에 libvirt KVM 가상화 환경과 VXLAN 오버레이 네트워크를 자동으로 구성하는 Ansible 플레이북

### 주요 기능
- **common role**: 공통 패키지 설치, IP forwarding, 커널 모듈 로드
- **vxlan role**: VXLAN 인터페이스(VNI 100) 생성, br-vxlan 브리지 구성, Netplan 영속성 설정
- **libvirt role**: KVM/QEMU 설치, 스토리지 풀 구성, vxlan-network 정의

### 네트워크 구성
```
┌─────────────────────────────────────────────────────────┐
│           VXLAN Overlay (VNI 100, 10.200.1.0/24)        │
└─────────────────────────────────────────────────────────┘
│                  │                  │
kvm-host01         kvm-host02         kvm-host03
10.200.1.1         10.200.1.2         10.200.1.3
192.168.0.50       192.168.0.46       192.168.0.49
```


## Test Plan

- [x] `ansible-playbook playbooks/site.yml` 실행 성공
- [x] `ansible-playbook playbooks/verify.yml` 검증 통과
  - [x] VXLAN 인터페이스 UP
  - [x] 브리지 인터페이스 UP
  - [x] FDB 엔트리 정상 등록
  - [x] 오버레이 네트워크 ping 테스트 (3개 호스트 간 모두 SUCCESS)
  - [x] libvirtd 서비스 실행 중
  - [x] vxlan-network active 상태